### PR TITLE
Test para dejar de seguir a un vendedor

### DIFF
--- a/src/test/java/com/meli/socialmeli/service/SellerServiceTest.java
+++ b/src/test/java/com/meli/socialmeli/service/SellerServiceTest.java
@@ -1,4 +1,0 @@
-package com.meli.socialmeli.service;
-
-public class SellerServiceTest {
-}

--- a/src/test/java/com/meli/socialmeli/service/SellerServiceTest.java
+++ b/src/test/java/com/meli/socialmeli/service/SellerServiceTest.java
@@ -1,0 +1,4 @@
+package com.meli.socialmeli.service;
+
+public class SellerServiceTest {
+}

--- a/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
+++ b/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
@@ -1,0 +1,74 @@
+package com.meli.socialmeli.service;
+
+import com.meli.socialmeli.constants.Messages;
+import com.meli.socialmeli.dto.response.ResponseDto;
+import com.meli.socialmeli.entity.Seller;
+import com.meli.socialmeli.entity.User;
+import com.meli.socialmeli.exception.NotFoundException;
+import com.meli.socialmeli.repository.ISellerRepository;
+import com.meli.socialmeli.repository.IUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private IUserRepository userRepository;
+
+    @Mock
+    private ISellerRepository sellerRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private final Integer userId = 1;
+    private final Integer sellerId = 1;
+    private final Integer sellerIdToUnfollow = 1;
+
+    @Test
+    @DisplayName("US-0007 - Dejar de seguir un vendedor exitosamente")
+    void testUnfollowSeller_Success() {
+        // Arrange
+        User mockUser = new User();
+        Seller mockSeller = new Seller();
+        when(userRepository.getById(userId)).thenReturn(Optional.of(mockUser));
+        when(sellerRepository.getById(sellerId)).thenReturn(Optional.of(mockSeller));
+        when(sellerRepository.isFollower(mockSeller, mockUser)).thenReturn(true);
+
+        // Act
+        ResponseDto response = userService.unfollowSeller(userId, sellerId);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(Messages.SUCCESS_UNFOLLOW, response.getMessage());
+        verify(userRepository).unfollowSeller(mockUser, mockSeller);
+        verify(sellerRepository).removeFollower(mockSeller, mockUser);
+    }
+
+    @Test
+    @DisplayName("TEST-002: Verificar que al dejar de seguir a un vendedor si el vendedor no existe, se lanza una excepción")
+    void testUnfollowSellerException() {
+        // Arrange
+        User mockUser = new User();
+        when(userRepository.getById(userId)).thenReturn(Optional.of(mockUser));
+        when(sellerRepository.getById(sellerIdToUnfollow)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerIdToUnfollow));
+    }
+
+
+
+
+}

--- a/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
+++ b/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
@@ -34,7 +34,6 @@ public class UserServiceTest {
 
     private final Integer userId = 1;
     private final Integer sellerId = 1;
-    private final Integer sellerIdToUnfollow = 1;
 
     @Test
     @DisplayName("US-0007 - Dejar de seguir un vendedor exitosamente")
@@ -62,7 +61,7 @@ public class UserServiceTest {
         // Arrange
         User mockUser = new User();
         when(userRepository.getById(userId)).thenReturn(Optional.of(mockUser));
-        when(sellerRepository.getById(sellerIdToUnfollow)).thenReturn(Optional.empty());
+        when(sellerRepository.getById(sellerId)).thenReturn(Optional.empty());
 
         // Act & Assert
         assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerIdToUnfollow));

--- a/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
+++ b/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
@@ -36,8 +36,8 @@ public class UserServiceTest {
     private final Integer sellerId = 1;
 
     @Test
-    @DisplayName("US-0007 - Dejar de seguir un vendedor exitosamente")
-    void testUnfollowSeller_Success() {
+    @DisplayName("TEST-002 - Dejar de seguir un vendedor exitosamente")
+    void testUnfollowSellerOk() {
         // Arrange
         User mockUser = new User();
         Seller mockSeller = new Seller();
@@ -67,6 +67,29 @@ public class UserServiceTest {
         assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerId));
     }
 
+    @Test
+    @DisplayName("TEST-002: Verificar que al dejar de seguir a un vendedor si el usuario no existe, se lanza una excepción")
+    void testUnfollowSeller_UserNotFound() {
+        // Arrange
+        when(userRepository.getById(userId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerId));
+    }
+
+    @Test
+    @DisplayName("TEST-002: Verificar que al dejar de seguir a un vendedor si el usuario no lo sigue, se lanza una excepción")
+    void testUnfollowSeller_UserNotFollowingSeller() {
+        // Arrange
+        User mockUser = new User();
+        Seller mockSeller = new Seller();
+        when(userRepository.getById(userId)).thenReturn(Optional.of(mockUser));
+        when(sellerRepository.getById(sellerId)).thenReturn(Optional.of(mockSeller));
+        when(sellerRepository.isFollower(mockSeller, mockUser)).thenReturn(false);
+
+        // Act & Assert
+        assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerId));
+    }
 
 
 

--- a/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
+++ b/src/test/java/com/meli/socialmeli/service/UserServiceTest.java
@@ -64,7 +64,7 @@ public class UserServiceTest {
         when(sellerRepository.getById(sellerId)).thenReturn(Optional.empty());
 
         // Act & Assert
-        assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerIdToUnfollow));
+        assertThrows(NotFoundException.class, () -> userService.unfollowSeller(userId, sellerId));
     }
 
 


### PR DESCRIPTION
Verificar que el usuario a dejar de seguir exista. (US-0007). Se incluyen 2 tests unitarios.

Se cumple:
Permite continuar con normalidad.

No se cumple:
Notifica la no existencia mediante una excepción.



